### PR TITLE
Single container deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:18-slim AS frontend-builder
+WORKDIR /usr/src/app
+
+COPY client/package*.json ./
+RUN npm ci
+COPY client/ ./
+RUN npm run build
+RUN npm ci --omit=dev
+
+
+FROM node:18-slim AS backend-builder
+WORKDIR /usr/src/app
+
+COPY server/package*.json ./
+RUN npm ci
+COPY server/ ./
+RUN npm run build
+RUN npm ci --omit=dev
+
+
+#FROM gcr.io/distroless/nodejs:18
+FROM node:18-slim
+EXPOSE 8080
+WORKDIR /usr/src/app
+
+COPY --from=backend-builder /usr/src/app/dist/ ./
+COPY --from=backend-builder /usr/src/app/node_modules ./node_modules
+COPY --from=frontend-builder /usr/src/app/dist/client/ public/
+
+CMD ["server.js"]

--- a/client/src/app/employee.service.ts
+++ b/client/src/app/employee.service.ts
@@ -7,7 +7,7 @@ import { Employee } from './employee';
   providedIn: 'root'
 })
 export class EmployeeService {
-  private url = 'http://localhost:5200';
+  private url = `${location.origin}`;
   private employees$: Subject<Employee[]> = new Subject();
 
   constructor(private httpClient: HttpClient) { }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,8 +1,12 @@
 import * as dotenv from "dotenv";
 import cors from "cors";
 import express from "express";
+import path from "path";
 import { connectToDatabase } from "./database";
 import { employeeRouter } from "./employee.routes";
+
+// Cloud Run defaults to 8080 but checking PORT is a best practice.
+const port = Number(process.env["PORT"]) || 8080;
 
 // Load environment variables from the .env file, where the ATLAS_URI is configured
 dotenv.config();
@@ -18,12 +22,16 @@ connectToDatabase(ATLAS_URI)
     .then(() => {
         const app = express();
         app.use(cors());
+
+        // API
         app.use("/employees", employeeRouter);
 
-        // start the Express server
-        app.listen(5200, () => {
-            console.log(`Server running at http://localhost:5200...`);
-        });
+        // Serve client UI assets on root route /
+        app.use(express.static(path.join(__dirname, "public")));
 
+        // Start the Express server
+        app.listen(port, () => {
+            console.log(`Server listening on :${port}`);
+        });
     })
     .catch(error => console.error(error));


### PR DESCRIPTION
This pull request is useful for anyone who wants to deploy a single container to Cloud Run and serve the frontend assets from the backend's public directory for static assets. The single-deploy version of `Dockerfile` is at the root of the repo. Supporting this requires adding static middleware to `server/main.ts`; however no changes to the client are necessary (the nginx configuration is ignored).

This enhancement also helps to support a
[separate project](https://github.com/GoogleCloudPlatform/terraform-mean-cloudrun-mongodb) that wants to deploy a single container instance to Cloud Run, at least initially, with a Terraform script.

The Cloud Run instance needs to have the `ATLAS_URI` environment configured with a valid connection string to the MongoDB Atlas instance.