### PR TITLE
Add employee's name min length validation as 3

### DIFF
--- a/client/src/app/employee-form/employee-form.component.ts
+++ b/client/src/app/employee-form/employee-form.component.ts
@@ -84,7 +84,7 @@ export class EmployeeFormComponent implements OnInit {
   ngOnInit() {
     this.initialState.subscribe(employee => {
       this.employeeForm = this.fb.group({
-        name: [ employee.name, [Validators.required] ],
+        name: [ employee.name, [Validators.required, Validators.minLength(3) ] ],
         position: [ employee.position, [ Validators.required, Validators.minLength(5) ] ],
         level: [ employee.level, [Validators.required] ]
       });


### PR DESCRIPTION
### Add Name Length Validation to EmployeeFormComponent
I 've noticed that the template of **[EmployeeFormComponent](https://github.com/mongodb-developer/mean-stack-example/blob/main/client/src/app/employee-form/employee-form.component.ts)** checks if there's an error due to employee name minLength validation, but on the other hand the form control **name** doesn't have that validation, so i added it to be min **3** as the template expected