### PR TITLE
Track codespace create/start events

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,8 +31,8 @@
       "label": "MongoDB"
     }
   },
-  "postCreateCommand": "npm install",
-  "postStartCommand": "bash -lc 'for i in {1..60}; do mongosh --quiet \"$DATABASE_URI\" --eval \"db.hello().isWritablePrimary\" | grep -q true && break; sleep 2; done; npm run seed'",
+  "postCreateCommand": "npm install && bash .devcontainer/track.sh created || true",
+  "postStartCommand": "bash -lc 'for i in {1..60}; do mongosh --quiet \"$DATABASE_URI\" --eval \"db.hello().isWritablePrimary\" | grep -q true && break; sleep 2; done; npm run seed; bash .devcontainer/track.sh started || true'",
   "remoteEnv": {
     "DATABASE_URI": "mongodb://localhost:27017/meanStackExample?appName=mean-stack-example-devcontainer"
   }

--- a/.devcontainer/track.sh
+++ b/.devcontainer/track.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Best-effort telemetry: log a codespace lifecycle event. Never fails the caller.
+EVENT="${1:-unknown}"
+URL="https://us-central1-project-learning-fuel.cloudfunctions.net/trackCodespace"
+curl -fsS -m 5 -X POST "$URL" \
+  -H "Content-Type: application/json" \
+  -d "{\"event\":\"$EVENT\",\"codespace\":\"${CODESPACE_NAME:-}\",\"user\":\"${GITHUB_USER:-}\",\"repository\":\"${GITHUB_REPOSITORY:-mongodb-developer/mean-stack-example}\"}" \
+  >/dev/null 2>&1 || true


### PR DESCRIPTION
## What
Adds lightweight telemetry that records every time a Codespace is **created** or **started/resumed** from this repo.

## How
- New `.devcontainer/track.sh`: a best-effort `curl` (5s timeout, silent) that POSTs `{event, codespace, user, repository}` to an HTTP Google Cloud Function.
- `devcontainer.json`: fires `track.sh created` from `postCreateCommand` and `track.sh started` from `postStartCommand`. Both use `|| true`, so telemetry can never break the dev environment.

## Backend (already deployed)
- Gen2 HTTP function `trackCodespace` in GCP project `project-learning-fuel` (`us-central1`), Node 22.
- Inserts into `githubtraffic.codespaceEvents` on MongoDB Atlas.
- Atlas URI read from Secret Manager (`mongodb_uri`); runtime SA granted `secretmanager.secretAccessor`.
- Verified end-to-end: test POST returns HTTP 204 and writes a document.