### PR TITLE
Fix Codespaces host rejection in Angular SSR host check

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -30,7 +30,7 @@
             "server": "src/main.server.ts",
             "outputMode": "server",
             "security": {
-              "allowedHosts": ["localhost", ".app.github.dev"]
+              "allowedHosts": ["localhost", "*.app.github.dev"]
             },
             "ssr": {
               "entry": "server.ts"
@@ -68,6 +68,9 @@
         },
         "serve": {
           "builder": "@angular/build:dev-server",
+          "options": {
+            "allowedHosts": ["*.app.github.dev"]
+          },
           "configurations": {
             "production": {
               "buildTarget": "client:build:production"


### PR DESCRIPTION
## Problem

Running the client in Codespaces still fails with:

> Header "x-forwarded-host" with value "…-4200.app.github.dev" is not allowed.

## Root cause

`@angular/ssr`'s `isHostAllowed` only treats an `allowedHosts` entry as a wildcard when it **starts with `*.`**:

```js
for (const allowedHost of allowedHosts) {
  if (!allowedHost.startsWith('*.')) continue;   // ".app.github.dev" is skipped
  if (hostname.endsWith(allowedHost.slice(1))) return true;
}
```

The existing entry `.app.github.dev` (leading dot) is therefore ignored, and the forwarded Codespaces host is rejected. Also, `ng serve` (what Codespaces runs) validates against the **serve** target's `allowedHosts`, not the build target's `security.allowedHosts`, which had no entry at all.

## Fix

- `build.security.allowedHosts`: `.app.github.dev` → `*.app.github.dev`.
- `serve.options.allowedHosts`: add `*.app.github.dev`.

## Verification
- `ng build` succeeds; `angular.json` is valid.
- Reproduced `@angular/ssr`'s matcher: `*.app.github.dev` allows `…-4200.app.github.dev` and `localhost`, and rejects unrelated hosts.